### PR TITLE
tmuxのキーバインド再設定

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,5 +1,4 @@
 ## general
-setw -g utf8 on               # UTF-8で使用
 set -g bell-action none       # ベル無効
 set -g mode-key vi            # viキーバインド
 set -g default-command ""     # クップボード共有無効
@@ -21,7 +20,6 @@ set -g pane-border-fg black
 set -g pane-active-border-fg brightblue
 
 # status line
-set -g status-utf8 on
 set -g status-justify left
 set -g status-bg default
 set -g status-fg colour12

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -113,6 +113,13 @@ bind C-q confirm-before 'kill-server' # 全セッション終了
 bind | split-window -h  # ペインを縦に分割
 bind - split-window -v  # ペインを横に分割
 
+bind h select-pane -L   # ペイン左に移動
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R   # ペイン右に移動
+bind -r C-h select-window -t :-
+bind -r C-l select-window -t :+
+
 bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
 bind -n WheelDownPane select-pane -t= \; send-keys -M
 bind -n C-WheelUpPane select-pane -t= \; copy-mode -e \; send-keys -M


### PR DESCRIPTION
vimキーバインドを削除してしまっているので、再設定すること。
現在は `prefix+h, l` が使えなくて不便である。

```
# Vimのキーバインドでペインを移動する
bind h select-pane -L
bind j select-pane -D
bind k select-pane -U
bind l select-pane -R
bind -r C-h select-window -t :-
bind -r C-l select-window -t :+
```